### PR TITLE
JSXトランスパイル形式を配列ベースに変更する

### DIFF
--- a/transpiler/index.ts
+++ b/transpiler/index.ts
@@ -10,38 +10,38 @@ const readFile: (path: string) => Promise<string> =
         path => Bun.file(path).text() :
         path => NodeReadFile(path).then(e=>e.toString());
 
-export const bun_llex = (importSource: string = "llex"): BunPlugin => ({
+export const bun_llex = (): BunPlugin => ({
     name: "bun-llex",
     setup(build) {
         build.onLoad({ filter: /\.jsx$/ }, async args => {
             const code = await readFile(args.path);
             return ({
-                contents: transpile(code, importSource, false),
+                contents: transpile(code, false),
                 loader: "jsx"
             });
         });
         build.onLoad({ filter: /\.tsx$/ }, async args => {
             const code = await readFile(args.path);
             return ({
-                contents: transpile(code, importSource, true),
+                contents: transpile(code, true),
                 loader: "tsx"
             });
         });
     },
 })
 
-export const rollup_llex = (importSource: string = "llex"): RollupPlugin => ({
+export const rollup_llex = (): RollupPlugin => ({
     name: "rollup-llex",
     load(id){
         if(id.endsWith(".jsx")){
             const code = readFileSync(id).toString();
             return {
-                code: transpile(code, importSource, false)
+                code: transpile(code, false)
             };
         }else if(id.endsWith(".tsx")){
             const code = readFileSync(id).toString();
             return {
-                code: transpile(code, importSource, true)
+                code: transpile(code, true)
             };
         }
     }

--- a/transpiler/transpile.ts
+++ b/transpiler/transpile.ts
@@ -3,18 +3,8 @@ import traverse from "@babel/traverse";
 import generate from "@babel/generator";
 import * as t from "@babel/types";
 
-const generateUniqueName = (base: string, used: Set<string>): string => {
-    let name = base;
-    let counter = 1;
-    while(used.has(name))
-        name = `${base}$${counter++}`;
-    return name;
-}
-
 const jsxAttr2Object = (
     ast: (t.JSXAttribute | t.JSXSpreadAttribute)[],
-    jsx: string,
-    frag: string
 ): t.ObjectExpression => t.objectExpression(ast.map(e=>
     e.type === "JSXAttribute" ?
         t.objectProperty(
@@ -25,7 +15,7 @@ const jsxAttr2Object = (
             e.value ?
                 e.value.type === "StringLiteral" ?
                     e.value :
-                    jsx2Expression(e.value, jsx, frag, true) :
+                    jsx2Expression(e.value, true) :
                 t.booleanLiteral(true)) :
         t.spreadElement(e.argument)
 ));
@@ -34,44 +24,53 @@ const filterEmptyString = (ast: t.Expression | t.SpreadElement) => !(ast.type ==
 
 const jsx2Elements = (
     ast: ReturnType<typeof t.jsxFragment>["children"] extends (infer P)[] ? P : never,
-    jsx: string,
-    frag: string,
     dontTrim?: boolean
 ): t.Expression | t.SpreadElement => {
     if(ast.type === "JSXSpreadChild")
         return t.spreadElement(ast.expression);
     else
-        return jsx2Expression(ast, jsx, frag, dontTrim);
+        return jsx2Expression(ast, dontTrim);
 }
 
 const jsx2Expression = (
     ast: ReturnType<typeof t.jsxFragment>["children"] extends (infer P)[] ? P : never,
-    jsx: string,
-    frag: string,
     dontTrim?: boolean
 ): t.Expression => {
     switch(ast.type){
         case "JSXText": return t.stringLiteral(dontTrim ? ast.value : ast.value.trim());
-        case "JSXFragment": return t.callExpression(
-                t.identifier(frag),
-                ast.children.map(child=>jsx2Elements(child, jsx, frag)).filter(filterEmptyString)
-            );
+        case "JSXFragment": return t.arrayExpression([
+                t.nullLiteral(),
+                t.objectExpression([]),
+                ...ast.children.map(child=>jsx2Elements(child)).filter(filterEmptyString)
+            ]);
         case "JSXElement":
             const tag = ast.openingElement.name;
             if(tag.type === "JSXIdentifier" && /^[a-z]/.test(tag.name)){
-                return t.callExpression(
-                    t.memberExpression(
-                        t.identifier(jsx),
-                        t.identifier(tag.name)
-                    ), [
-                        jsxAttr2Object(ast.openingElement.attributes, jsx, frag),
-                        ...ast.children.map(child=>jsx2Elements(child, jsx, frag)).filter(filterEmptyString)
-                    ]
-                )
+                return t.arrayExpression([
+                    t.stringLiteral(tag.name),
+                    t.objectExpression(ast.openingElement.attributes.map(attr => {
+                        if (attr.type === "JSXAttribute") {
+                            if (attr.name.type === "JSXNamespacedName")
+                                console.warn("Warning: JSXNamespacedName is not supported");
+                            const { name } = attr.name;
+                            return t.objectProperty(
+                                t.identifier(typeof name === "string" ? name : name.name),
+                                attr.value
+                                    ? attr.value.type === "StringLiteral"
+                                        ? attr.value
+                                        : jsx2Expression(attr.value)
+                                    : t.booleanLiteral(true)
+                            );
+                        } else {
+                            return t.spreadElement(attr.argument);
+                        }
+                    })),
+                    ...ast.children.map(child => jsx2Elements(child)).filter(filterEmptyString)
+                ])
             }else switch(tag.type){
                 case "JSXIdentifier":
                     return t.callExpression(t.identifier(tag.name), [
-                        jsxAttr2Object(ast.openingElement.attributes, jsx, frag)
+                        jsxAttr2Object(ast.openingElement.attributes)
                     ]);
                 default:
                     throw new Error("not implemented");
@@ -80,18 +79,19 @@ const jsx2Expression = (
                 case "JSXEmptyExpression":
                     return t.booleanLiteral(true);
                 case "JSXElement": case "JSXFragment":
-                    return jsx2Expression(ast.expression, jsx, frag);
+                    return jsx2Expression(ast.expression);
                 default:
                     return ast.expression;
             }
-        case "JSXSpreadChild": return t.callExpression(
-                t.identifier(frag),
-                [t.spreadElement(ast.expression)]
-            );
+        case "JSXSpreadChild": return t.arrayExpression([
+            t.nullLiteral(),
+            t.objectExpression([]),
+            t.spreadElement(ast.expression)
+        ]);
     }
 }
 
-export const transpile = (code: string, importSource: string, isTypeScript: boolean): string => {
+export const transpile = (code: string, isTypeScript: boolean): string => {
     const ast = parse(code, {
         sourceType: "module",
         plugins: isTypeScript ? ["typescript", "jsx"] : ["jsx"]
@@ -104,22 +104,12 @@ export const transpile = (code: string, importSource: string, isTypeScript: bool
         }
     });
 
-    const jsx_identifier = generateUniqueName("jsx", identifiers);
-    const fragment_identifier = generateUniqueName("fragment", identifiers);
-
-    ast.program.body.unshift(
-        t.importDeclaration([
-            t.importSpecifier(t.identifier(jsx_identifier), t.identifier("jsx")),
-            t.importSpecifier(t.identifier(fragment_identifier), t.identifier("fragment"))
-        ], t.stringLiteral(importSource))
-    );
-
     traverse(ast, {
         JSXElement(ast){
-            ast.replaceWith(jsx2Expression(ast.node, jsx_identifier, fragment_identifier));
+            ast.replaceWith(jsx2Expression(ast.node));
         },
         JSXFragment(ast){
-            ast.replaceWith(jsx2Expression(ast.node, jsx_identifier, fragment_identifier));
+            ast.replaceWith(jsx2Expression(ast.node));
         }
     });
     return generate(ast).code;


### PR DESCRIPTION
JSXトランスパイル形式を配列ベースに変更しました。

## 理由
1. ProxyベースのJSX生成関数と大差無いサイズを有していたため
2. 配列演算子は、Proxyベース生成関数と比べ、JITにより速度面で有利になると考えられたため

## 破壊点
配列ベースの出力により、`llex`の依存関係を必要としないため、
プラグインの引数`importSource`が削除されました。