### PR TITLE
内部DOM操作メソッドを関数型(?)にしてパフォーマンスを向上させる

### DIFF
--- a/packages/lunet/src/mount/dom/index.ts
+++ b/packages/lunet/src/mount/dom/index.ts
@@ -1,28 +1,51 @@
 import type { JSXComponent, JSXElement, JSXFragment, JSXNode } from "../../jsx";
-import { renderComponent } from "./component";
-import { renderElement } from "./element";
-import { renderFragment } from "./fragment";
-import { renderText } from "./text";
+import { createText,      updateText,      revokeText,      afterText } from "./text";
+import { createElement,   updateElement,   revokeElement,   afterElement } from "./element";
+import { createFragment,  updateFragment,  revokeFragment,  afterFragment } from "./fragment";
+import { createComponent, updateComponent, revokeComponent, afterComponent } from "./component";
 
-export type RenderedDOM<T extends JSXNode> = {
-    // type: T extends string ? 0 : T extends JSXElement ? 1 : T extends JSXFragment ? 2 : T extends JSXComponent ? 3 : never, // 0 種類
-    // flat(): (JSXElement | string)[], // 1 差分比較用のフラットJSX出力関数
-    update(jsx: T): void,              // 2 差分更新関数
-    render(): Node,                    // 3 初回・トラブル時にフル描画をする関数
-    revoke(): void,                    // 4 破棄関数
-    after(node: Node): void,           // 5 挿入関数
+export type RenderedDOM<T extends JSXNode> =
+    T extends string       ? [0, string,       Text] :
+    T extends JSXElement   ? [1, JSXElement,   HTMLElement, RenderedDOM<any>[]] :
+    T extends JSXFragment  ? [2, JSXFragment,  Comment,     RenderedDOM<any>[]] :
+    T extends JSXComponent ? [3, JSXComponent, RenderedDOM<JSXFragment>] :
+    never;
+
+export const createNode = (jsx: JSXNode): [RenderedDOM<any>, Node] => {
+    if(typeof jsx === "string"){
+        return createText(jsx);
+    }else if(typeof jsx[0] === "string"){
+        return createElement(jsx);
+    }else if(jsx[0] === null){
+        return createFragment(jsx);
+    }else{
+        return createComponent(jsx);
+    }
 }
 
-export type UnknownRenderedDOM = RenderedDOM<string> | RenderedDOM<JSXElement> | RenderedDOM<JSXFragment> | RenderedDOM<JSXComponent>;
+export const updateNode = (dom: RenderedDOM<any>, jsx: any) => {
+    switch (dom[0]) {
+        case 0: return updateText(dom, jsx);
+        case 1: return updateElement(dom, jsx);
+        case 2: return updateFragment(dom, jsx);
+        case 3: return updateComponent(dom, jsx);
+    }
+}
 
-export const renderNode = (jsx: JSXNode): UnknownRenderedDOM => {
-    if(typeof jsx === "string"){
-        return renderText(jsx);
-    }else if(typeof jsx[0] === "string"){
-        return renderElement(jsx);
-    }else if(jsx[0] === null){
-        return renderFragment(jsx);
-    }else{
-        return renderComponent(jsx);
+export const revokeNode = (dom: RenderedDOM<any>) => {
+    switch (dom[0]) {
+        case 0: return revokeText(dom);
+        case 1: return revokeElement(dom);
+        case 2: return revokeFragment(dom);
+        case 3: return revokeComponent(dom);
+    }
+}
+
+export const afterNode = (dom: RenderedDOM<any>, node: Node) => {
+    switch (dom[0]) {
+        case 0: return afterText(dom, node);
+        case 1: return afterElement(dom, node);
+        case 2: return afterFragment(dom, node);
+        case 3: return afterComponent(dom, node);
     }
 }

--- a/packages/lunet/src/mount/dom/text.ts
+++ b/packages/lunet/src/mount/dom/text.ts
@@ -1,14 +1,19 @@
 import type { RenderedDOM } from ".";
 
-export const renderText = (text: string): RenderedDOM<string> => {
-    let node: Text | null;
+export const createText = (jsx: string): [RenderedDOM<string>, Text] => {
+    const node = new Text(jsx);
+    return [[0, jsx, node], node];
+}
 
-    return {
-        // type: 0,
-        // flat: () => [currentText],
-        update(t){ text !== t && (node!.textContent = text = t) },
-        render: () => node = new Text(text),
-        revoke(){ node!.remove() },
-        after(n) { node!.parentNode!.insertBefore(n, node!.nextSibling) },
-    }
+export const updateText = (dom: RenderedDOM<string>, jsx: string) => {
+    if (dom[1] !== jsx)
+        dom[2]!.textContent = dom[1] = jsx;
+}
+
+export const revokeText = (dom: RenderedDOM<string>): void => (
+    dom[2].remove()
+)
+
+export const afterText = (dom: RenderedDOM<string>, node: Node): void => {
+    dom[2].parentNode?.insertBefore(node, dom[2].nextSibling)
 }

--- a/packages/lunet/src/mount/index.ts
+++ b/packages/lunet/src/mount/index.ts
@@ -1,16 +1,17 @@
 import type { JSXNode } from "../jsx";
-import { renderNode, type UnknownRenderedDOM } from "./dom";
+import { createNode, revokeNode, type RenderedDOM } from "./dom";
 
 type RenderFunction = (el: HTMLElement, jsx: JSXNode) => void;
 
-const rootMap = new WeakMap<HTMLElement, UnknownRenderedDOM>();
+const rootMap = new WeakMap<HTMLElement, RenderedDOM<any>>();
 
 export const render: RenderFunction = (el, jsx) => {
-    rootMap.get(el)?.revoke();
+    if (rootMap.has(el))
+        revokeNode(rootMap.get(el)!);
 
-    const root = renderNode(jsx);
+    const [root, node] = createNode(jsx);
 
     rootMap.set(el, root);
 
-    el.append(root.render());
+    el.append(node);
 }


### PR DESCRIPTION
今までは仮想DOMごとにクロージャー・関数を作ったせいでパフォーマンスが落ちてました。
今回関数型っぽい内部APIにして速くしました

## Before
| 環境 | 速度 | 追記 |
| - | - | - |
| Bun | 976.56ms/iter | 1秒以下に収めるとは流石Bun |
| Node.js | 1.50s/iter | V8搭載した先輩なのに<br>Bunに負けるのは草 |

## After
| 環境 | 速度 | 追記 |
| - | - | - |
| Bun | 434.64ms/iter | 半分ぐらい |
| Node.js | 660.42ms/iter | 速度比率はBeforeと同じぐらい |

## テスト
総当たりテストスイート(シード14)含め全て合格しました